### PR TITLE
Improved performance of converting text into tokens

### DIFF
--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -3,11 +3,9 @@
   <file src="src/Util/EncodeUtil.php">
     <LessSpecificReturnStatement>
       <code><![CDATA[array_map(hexdec(...), str_split(bin2hex($text), 2))]]></code>
-      <code><![CDATA[pack('C*', ...$bytes)]]></code>
     </LessSpecificReturnStatement>
     <MoreSpecificReturnType>
       <code><![CDATA[NonEmptyByteVector]]></code>
-      <code><![CDATA[non-empty-string]]></code>
     </MoreSpecificReturnType>
   </file>
   <file src="tests/Benchmark/EncoderBench.php">

--- a/src/Util/EncodeUtil.php
+++ b/src/Util/EncodeUtil.php
@@ -7,7 +7,6 @@ namespace Yethee\Tiktoken\Util;
 use function array_map;
 use function bin2hex;
 use function hexdec;
-use function pack;
 use function str_split;
 
 /** @psalm-type NonEmptyByteVector = non-empty-list<int<0, 255>> */
@@ -21,15 +20,5 @@ final class EncodeUtil
     public static function toBytes(string $text): array
     {
         return array_map(hexdec(...), str_split(bin2hex($text), 2));
-    }
-
-    /**
-     * @psalm-param NonEmptyByteVector $bytes
-     *
-     * @return non-empty-string
-     */
-    public static function fromBytes(array $bytes): string
-    {
-        return pack('C*', ...$bytes);
     }
 }

--- a/src/Vocab/Vocab.php
+++ b/src/Vocab/Vocab.php
@@ -104,22 +104,25 @@ final class Vocab implements Countable
         return new self($map);
     }
 
-    /** @psalm-param NonEmptyByteVector $bytes */
-    public function tryGetRank(array $bytes): int|null
+    public function tryGetRank(string $binary): int|null
     {
-        return $this->tokenToRankMap[EncodeUtil::fromBytes($bytes)] ?? null;
+        if ($binary === '') {
+            throw new InvalidArgumentException('Argument $binary cannot be an empty string');
+        }
+
+        return $this->tokenToRankMap[$binary] ?? null;
     }
 
-    /**
-     * @psalm-param NonEmptyByteVector $bytes
-     *
-     * @throws OutOfBoundsException
-     */
-    public function getRank(array $bytes): int
+    /** @throws OutOfBoundsException */
+    public function getRank(string $binary): int
     {
-        return $this->tokenToRankMap[EncodeUtil::fromBytes($bytes)] ?? throw new OutOfBoundsException(sprintf(
+        if ($binary === '') {
+            throw new InvalidArgumentException('Argument $binary cannot be an empty string');
+        }
+
+        return $this->tokenToRankMap[$binary] ?? throw new OutOfBoundsException(sprintf(
             'No rank for bytes vector: [%s]',
-            implode(', ', $bytes),
+            implode(', ', EncodeUtil::toBytes($binary)),
         ));
     }
 

--- a/tests/Vocab/VocabTest.php
+++ b/tests/Vocab/VocabTest.php
@@ -5,8 +5,9 @@ declare(strict_types=1);
 namespace Yethee\Tiktoken\Tests\Vocab;
 
 use PHPUnit\Framework\TestCase;
-use Yethee\Tiktoken\Util\EncodeUtil;
 use Yethee\Tiktoken\Vocab\Vocab;
+
+use function chr;
 
 final class VocabTest extends TestCase
 {
@@ -15,9 +16,9 @@ final class VocabTest extends TestCase
         $vocab = Vocab::fromFile(__DIR__ . '/Fixtures/test.tiktoken');
 
         self::assertCount(47, $vocab);
-        self::assertSame(285, $vocab->getRank(EncodeUtil::toBytes('is')));
+        self::assertSame(285, $vocab->getRank('is'));
         self::assertSame('is', $vocab->getToken(285));
-        self::assertSame(18, $vocab->getRank([51]));
+        self::assertSame(18, $vocab->getRank(chr(51)));
         self::assertSame('3', $vocab->getToken(18));
     }
 }


### PR DESCRIPTION
Encoding text is x2 times faster compared to  the version `0.3.0`.

*Measured for a text of 39k symbols of the Latin script. (baconipsum on screenshot)*

![image](https://github.com/yethee/tiktoken-php/assets/559488/5833b66b-e98d-4046-bf4d-12b4b38a5245)

<details>
  <summary>Benchmark report for version 0.3.0</summary>
  
![image](https://github.com/yethee/tiktoken-php/assets/559488/d1680fac-25e6-4045-ad7b-b158c6bab099)

</details>

Ref to issue: #6