### PR TITLE
add support for o1 models

### DIFF
--- a/src/EncoderProvider.php
+++ b/src/EncoderProvider.php
@@ -47,6 +47,7 @@ final class EncoderProvider implements ResetInterface
         ],
     ];
     private const MODEL_PREFIX_TO_ENCODING = [
+        "o1-": "o200k_base",
         'gpt-4o-' => 'o200k_base',
         'gpt-4-' => 'cl100k_base',
         'gpt-3.5-turbo-' => 'cl100k_base',

--- a/src/EncoderProvider.php
+++ b/src/EncoderProvider.php
@@ -47,7 +47,7 @@ final class EncoderProvider implements ResetInterface
         ],
     ];
     private const MODEL_PREFIX_TO_ENCODING = [
-        "o1-": "o200k_base",
+        'o1-' => 'o200k_base',
         'gpt-4o-' => 'o200k_base',
         'gpt-4-' => 'cl100k_base',
         'gpt-3.5-turbo-' => 'cl100k_base',


### PR DESCRIPTION
Added support for OpenAI o1-mini and o1-preview models by mapping them to the `o200k_base` encoding. This update ensures compatibility with the latest tiktoken changes as introduced in version 0.8.0 of the official library.

Fixes compatibility issues with models not yet included in tiktoken-php.